### PR TITLE
dashboard-link for extra small devices

### DIFF
--- a/components/shared/app/assets/stylesheets/shared/dashboard.scss
+++ b/components/shared/app/assets/stylesheets/shared/dashboard.scss
@@ -63,6 +63,15 @@
   }
 
   .links {
+    .dashboard-link {
+      @extend .col-xs-4;
+
+      // For extra small devices
+      @media (max-width: 501px) {
+        width: 100%;
+      }
+    }
+
     a {
       vertical-align: middle;
       background-color: #eceff4;

--- a/components/shared/app/helpers/shared/dashboard_helper.rb
+++ b/components/shared/app/helpers/shared/dashboard_helper.rb
@@ -1,7 +1,7 @@
 module Shared::DashboardHelper
   def dashboard_link(icon, number, description, path, type)
     html = <<-HTML
-      <div class="col-xs-4">
+      <div class="dashboard-link">
         <a href="#{path}">
           <div class="link-icon #{type}">#{fa_icon icon}</div>
           <div class="link-text">


### PR DESCRIPTION
Dashboard links sa na veľmi malých obrazovkách nezobrazujú korektne.

Before:
![image](https://user-images.githubusercontent.com/7534274/72645659-73cc9b80-3974-11ea-9ab9-7c3992e27787.png)

After:
![image](https://user-images.githubusercontent.com/7534274/72645691-7fb85d80-3974-11ea-9eac-1156aca489dd.png)

Keďže bootstrap nepozná (až) také malé obrazovky, bolo nutné použiť konštantu. Širka `501px` je najmenšia šírka kontajnera, pokiaľ nie je `100%`.
![image](https://user-images.githubusercontent.com/7534274/72645814-c908ad00-3974-11ea-98ec-f91b21213ab6.png)
